### PR TITLE
fix assessment.set_data for unencrypted saving

### DIFF
--- a/assessment_model.php
+++ b/assessment_model.php
@@ -201,7 +201,7 @@ class Assessment {
             }
             else {
                 $stmt = $this->mysqli->prepare("UPDATE " . $this->tablename . " SET `data` = ?, `mdate` = ? WHERE `id` = ?");
-                $stmt->bind_param("sbi", $data, $mdate, $id);
+                $stmt->bind_param("ssi", $data, $mdate, $id);
                 $stmt->execute();
             }
 


### PR DESCRIPTION
when encryption was introduced in [this commit](https://github.com/emoncms/MyHomeEnergyPlanner/commit/b8cdc373ceb31e27c748edc742c895b1e3ca6bc5) it seems a regression was introduced for the *unencrypted* case

[before](https://github.com/emoncms/MyHomeEnergyPlanner/commit/b8cdc373ceb31e27c748edc742c895b1e3ca6bc5#diff-cf61664e1cfe788691c11932541428c0L175) (works):

```
$stmt->bind_param("ssi", $data, $mdate, $id);
```

[after](https://github.com/emoncms/MyHomeEnergyPlanner/commit/b8cdc373ceb31e27c748edc742c895b1e3ca6bc5#diff-cf61664e1cfe788691c11932541428c0L190) (fails):

```
$stmt->bind_param("sbi", $data, $mdate, $id);
```

from [the docs](https://www.php.net/manual/en/mysqli-stmt.bind-param.php) we see that `s` means `string` and `b` means `blob`.

note: it's not clear to me why `mdate` (`array('type' => 'int(11)')`) should
be treated as a string, but that's how it was before, and I've tested
that `ssi` works when `sbi` does not.